### PR TITLE
feat: Add import utility for parsing music catalog items

### DIFF
--- a/import-script.ts
+++ b/import-script.ts
@@ -1,0 +1,43 @@
+import { importAlbumFromUrl } from './import.ts';
+import { Album } from './types.ts';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const urls = [
+    "https://www.edmliveset.com/livesets/adam-beyer-ultra-japan-2025-resistance/",
+    "https://www.edmliveset.com/livesets/gorgon-city-live-at-ants-ibiza-2025-ushuaia-ibiza/",
+    "https://www.edmliveset.com/livesets/gorgon-city-live-at-creamfields-2025-sunday-steel-yard/",
+    "https://www.edmliveset.com/livesets/eli-brown-live-at-creamfields-2025-saturday-steel-yard/",
+    "https://www.edmliveset.com/livesets/max-styler-live-at-creamfields-2025-saturday-halo/",
+    "https://www.edmliveset.com/livesets/mau-p-live-at-creamfields-2025-friday-apex/",
+    "https://www.edmliveset.com/livesets/john-summit-live-at-creamfields-2025-friday-steel-yard/",
+    "https://www.edmliveset.com/livesets/adam-beyer-live-at-creamfields-2025-friday-steel-yard/",
+    "https://www.edmliveset.com/livesets/adam-beyer-live-at-awakenings-festival-2025-beekse-bergen-netherlands/",
+    "https://www.edmliveset.com/livesets/mau-p-live-at-awakenings-festival-2025-beekse-bergen-netherlands/",
+    "https://www.edmliveset.com/livesets/cassian-live-at-tomorrowland-2025-w2-day-3-freedom-stage/",
+    "https://www.edmliveset.com/livesets/kaskade-live-at-tomorrowland-2025-w2-day-1-mainstage/",
+    "https://www.edmliveset.com/livesets/cassian-b2b-kevin-de-vries-live-at-tomorrowland-2025-day-2-mainstage/",
+    "https://www.edmliveset.com/livesets/hi-lo-amp-eli-brown-live-at-tomorrowland-2025-day-1-freedom-stage/",
+];
+
+async function runImport() {
+  const importedAlbums: Album[] = [];
+  for (const url of urls) {
+    const album = await importAlbumFromUrl(url);
+    if (album) {
+      importedAlbums.push(album);
+    }
+  }
+
+  const newDataFileContent = `import { Album } from './types.ts';\n\nexport const importedAlbums: Album[] = ${JSON.stringify(importedAlbums, null, 2)};\n`;
+  fs.writeFileSync(path.join(__dirname, 'new-data.ts'), newDataFileContent);
+
+  console.log('Import complete. Data saved to new-data.ts');
+}
+
+runImport();

--- a/import.ts
+++ b/import.ts
@@ -1,0 +1,82 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { Album, Track } from './types.ts';
+import {v4 as uuidv4} from 'uuid';
+
+export async function importAlbumFromUrl(url: string): Promise<Album | null> {
+  try {
+    const { data } = await axios.get(url);
+    const $ = cheerio.load(data);
+
+    const title = $('h1.elementor-heading-title').first().text().trim();
+
+    let artist = $('.elementor-post-info__item--author a').first().text().trim();
+    if (!artist) {
+        artist = title.split('–')[0].trim();
+    }
+
+    const artwork = $('meta[property="og:image"]').attr('content') ||
+                  $('div.elementor-widget-theme-post-featured-image img').attr('src') ||
+                  '';
+
+    const tracks: Track[] = [];
+
+    $('.elementor-widget-theme-post-content p, .elementor-widget-text-editor .elementor-widget-container').each((i, container) => {
+        const contentHtml = $(container).html();
+        if (contentHtml) {
+            const lines = contentHtml.replace(/<p[^>]*>/g, '').replace(/<\/p>/g, '\n').split(/<br\s*\/?>|\n/i);
+            lines.forEach(line => {
+                const cleanLine = cheerio.load(line).text().trim();
+
+                // Try to match timestamp format
+                let match = cleanLine.match(/\[(.*?)\]\s*(.*)/);
+                let duration = '00:00';
+                let trackTitle = '';
+
+                if (match) {
+                    duration = match[1];
+                    trackTitle = match[2];
+                } else {
+                    // Try to match numbered list format
+                    match = cleanLine.match(/^(\d+)\s*(.*)/);
+                    if (match) {
+                        trackTitle = match[2];
+                    } else {
+                        trackTitle = cleanLine;
+                    }
+                }
+
+                if (trackTitle && trackTitle.trim().toLowerCase() !== 'id – id' && trackTitle.trim() !== '') {
+                    tracks.push({
+                        id: uuidv4(),
+                        title: trackTitle,
+                        artist: artist,
+                        duration: duration,
+                        artwork: artwork,
+                    });
+                }
+            });
+        }
+    });
+
+
+    if (!title || !artist || !artwork || tracks.length === 0) {
+      console.error(`Failed to parse complete data for ${url}`);
+      console.error(`Details: title='${title}', artist='${artist}', artwork='${artwork}', trackCount=${tracks.length}`);
+      return null;
+    }
+
+    const album: Album = {
+      id: uuidv4(),
+      title,
+      artist,
+      artwork,
+      tracks,
+    };
+
+    return album;
+  } catch (error) {
+    console.error(`Error during import from ${url}:`, error);
+    return null;
+  }
+}

--- a/new-data.ts
+++ b/new-data.ts
@@ -1,0 +1,1845 @@
+import { Album } from './types.ts';
+
+export const importedAlbums: Album[] = [
+  {
+    "id": "438bcd1e-d17c-4650-a716-41891ada314a",
+    "title": "Adam Beyer – Ultra Japan 2025 (Resistance)",
+    "artist": "Adam Beyer",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp",
+    "tracks": [
+      {
+        "id": "34da2d55-5dc2-4533-b154-a1f206235f57",
+        "title": "Oscar L & Charles D (USA) – Lift Me Up [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "04:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "a7b25cc5-fd3f-465f-b182-c121d528e6f8",
+        "title": "Mau P – Like I Like It (Eli Brown Edit)",
+        "artist": "Adam Beyer",
+        "duration": "08:40",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "b7d613da-82f8-423a-96e7-c083759649bb",
+        "title": "KASIA & Charles D (USA) ft. Sarah de Warren – Psycho [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "12:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "9a78a27e-662d-465c-8d14-953027642d36",
+        "title": "Faithless – We Come 1 (Adam Beyer Remix) [CHEEKY]",
+        "artist": "Adam Beyer",
+        "duration": "16:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "f714b60a-c8ad-4a02-b39a-7ac5e0714bc1",
+        "title": "LUSU – ID",
+        "artist": "Adam Beyer",
+        "duration": "20:10",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "d76acfc3-871b-4f7a-87bd-9e842c0b9998",
+        "title": "Anyma & Baset – Neverland (From Japan) (HNTR Remix) [THE END OF GENESYS/INTERSCOPE]",
+        "artist": "Adam Beyer",
+        "duration": "24:20",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "9c6e48fd-4253-4d13-960d-d7cba42eb2e9",
+        "title": "HI-LO – ID",
+        "artist": "Adam Beyer",
+        "duration": "27:45",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "4eef7552-c4b1-43f0-9d3f-f5f0ec3b5e9c",
+        "title": "Tao Andra – Rave In Progress [VOLTA]",
+        "artist": "Adam Beyer",
+        "duration": "35:20",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "0f6205fe-0937-45df-915b-ee86cbc69f64",
+        "title": "Technotronic – Pump Up The Jam (LUSU Remix) [UMG]",
+        "artist": "Adam Beyer",
+        "duration": "39:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "d50f7d99-f89e-40a3-88c4-977c8823d2d6",
+        "title": "Cirez D – On Off (ID Remix) [MOUSEVILLE]",
+        "artist": "Adam Beyer",
+        "duration": "42:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "a1192aa1-5843-4fdf-ab97-120feb1ff2bf",
+        "title": "Boys Noize & Human Resource – Dominator [ARMADA]",
+        "artist": "Adam Beyer",
+        "duration": "49:50",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "95fbd78b-5559-48a3-933f-c0f64bb88169",
+        "title": "Adam Beyer – Don’t Go [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "56:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "3d1ecb32-aba9-42ad-8a26-70d27be3f414",
+        "title": "Marco V – Loxia [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "59:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "051da0e1-b07b-4b8e-8be9-c97ca2c470af",
+        "title": "Kaufmann – Broncho’s Sandman [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "1:03:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "33af4690-4d46-47d8-a3bc-86aa39eaaaf6",
+        "title": "LUSU – Move 2 The Groove [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "1:07:40",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "d013cd95-3509-4b61-ba37-4ed4b84a84a7",
+        "title": "Goom Gum & RDNK – It’s Time To Get High [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "1:10:40",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "f47ac027-2e81-414b-9d53-008ffc4ec8c4",
+        "title": "Enrico Sangiuliano – The Techno Code (Charlotte de Witte Acid Code) [NINETOZERO]",
+        "artist": "Adam Beyer",
+        "duration": "1:14:50",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "b0787903-bc31-4cb5-8fe2-1b082e0eddb2",
+        "title": "Armin van Buuren & Adam Beyer vs. D-Shake – Techno Trance [DRUMCODE/ARMADA]",
+        "artist": "Adam Beyer",
+        "duration": "1:23:20",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "694847ec-8fce-471d-8544-be52e9616254",
+        "title": "Da Hool – Meet Her At The Love Parade (Daxson Remix) [FREE]",
+        "artist": "Adam Beyer",
+        "duration": "1:28:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "9038487b-40b1-4533-a711-7afa02b8d888",
+        "title": "Neumann & Bendtsen – Phantom Express [DERAILED RECORDS]",
+        "artist": "Adam Beyer",
+        "duration": "1:31:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "c8c9602a-d0b5-4b27-a367-c9aa795cd9e2",
+        "title": "Adam Beyer – Desert Queen [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "1:34:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "ba0b0d34-9159-4921-9659-6b14bbf425d0",
+        "title": "Adam Beyer & Bart Skils – Your Mind (ID Remix) [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "1:38:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "95f71d50-a891-4e66-a7d9-f9a0a14eb414",
+        "title": "HI-LO – Reese [DRUMCODE]",
+        "artist": "Adam Beyer",
+        "duration": "1:42:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "36cd5a04-38cb-4826-b14c-c1058d431627",
+        "title": "Sharam – PATT (Party All The Time) (Adam Beyer & Layton Giordani & Green Velvet Remix) [DRUMCODE/ARMADA]",
+        "artist": "Adam Beyer",
+        "duration": "1:45:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "17551735-b77f-4059-9b35-881d01b626ab",
+        "title": "Underworld – Rez (LAAT Remix) [JUNIOR BOY’S OWN]",
+        "artist": "Adam Beyer",
+        "duration": "1:49:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      },
+      {
+        "id": "cbc9e79e-6d1c-4c1b-a935-062bb7f71306",
+        "title": "Soul Central ft. Kathy Brown – Strings Of Life (Stronger On My Own) (Bart Skils & Weska Remix)",
+        "artist": "Adam Beyer",
+        "duration": "1:54:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/09/Ultra-Japan-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "44e6162d-73a9-44d5-b264-d700813094aa",
+    "title": "Gorgon City – Live at ANTS Ibiza 2025 (Ushuaia, Ibiza)",
+    "artist": "Gorgon City",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp",
+    "tracks": [
+      {
+        "id": "0b0602f9-2fb1-4034-bc63-8bd7884a3e2f",
+        "title": "Andrea Lane – Gorongosa [TOOLROOM TRAX]",
+        "artist": "Gorgon City",
+        "duration": "00:12",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "18261f40-45fc-4eb5-b03c-c514c5d78784",
+        "title": "Ugo Banchi – Dance With Ibiza (Linska Remix) [DIYNAMIC]",
+        "artist": "Gorgon City",
+        "duration": "06:58",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "a7fccb12-6e61-4098-a754-47a040bddc8b",
+        "title": "John Summit & Gorgon City ft. Rhys From The Sticks – Is Everybody Having Fun? [EXPERTS ONLY]",
+        "artist": "Gorgon City",
+        "duration": "09:55",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "36b99ae1-3f83-446f-be5f-2aa0af7efffc",
+        "title": "DREYA V – Up Front [REALM]",
+        "artist": "Gorgon City",
+        "duration": "13:24",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "fd8875c6-b521-410b-be6a-50746ebfd2e0",
+        "title": "Just Roi & DJ Mosh – Get Low [POP TOMORROW]",
+        "artist": "Gorgon City",
+        "duration": "17:38",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "a55d4ef2-09fe-4809-a4cb-b06391a9110a",
+        "title": "Chris Luno – Yes Baby [REALM]",
+        "artist": "Gorgon City",
+        "duration": "21:02",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "156dc2f0-1f80-4c06-9727-1bea20f4c32d",
+        "title": "Jay de Lys – I’m So Wavy [DEEPERFECT]",
+        "artist": "Gorgon City",
+        "duration": "24:29",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "e5cac030-a470-43fb-a873-2cc5d7385ab2",
+        "title": "Gorgon City – Voodoo [EMI]",
+        "artist": "Gorgon City",
+        "duration": "27:40",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "175dcb69-a2e8-429f-80f3-1e2dd76c85ec",
+        "title": "Cirez D – On Off [MOUSEVILLE]",
+        "artist": "Gorgon City",
+        "duration": "31:51",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "b98f9434-8927-4507-9e6b-724f4e3b9be9",
+        "title": "CHARMES & ED_PRJCT – On Repeat [STMPD]",
+        "artist": "Gorgon City",
+        "duration": "35:01",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "bd688bf4-5ca2-4a99-b7d8-14434f5c0950",
+        "title": "Azzecca – Forbidden Fruit [REALM]",
+        "artist": "Gorgon City",
+        "duration": "37:31",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "6ca56524-ce79-44c9-a1c9-a3ec4bf6a204",
+        "title": "ATFC ft. Lisa Millett – Bad Habit (Clüb De Combat Remix) [DEFECTED]",
+        "artist": "Gorgon City",
+        "duration": "40:41",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "237efbe8-f3a3-4b95-8156-0db4e899047b",
+        "title": "Gorgon City – 5 AM At Bagleys [REALM]",
+        "artist": "Gorgon City",
+        "duration": "45:44",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "d83d164f-a056-4be4-a24a-9b409450f884",
+        "title": "IDEMI – Someday [METHOD 808]",
+        "artist": "Gorgon City",
+        "duration": "53:29",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "eefaba4f-4001-4304-a1bc-c53ae7019bfe",
+        "title": "Linska – Bad Boy (GENESI Remix) [REALM]",
+        "artist": "Gorgon City",
+        "duration": "57:43",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "7c6d383d-0336-47f2-b68b-0534cf41bbb3",
+        "title": "Wallace – Willow [CWPT]",
+        "artist": "Gorgon City",
+        "duration": "1:01:36",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "99552e94-1418-4575-a089-cb6249d7032e",
+        "title": "Trutopia – Quick Sand [REALM]",
+        "artist": "Gorgon City",
+        "duration": "1:05:45",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "b10a5d39-83ee-43ba-87fc-a102f8892cda",
+        "title": "Gorgon City & DRAMA – You’ve Done Enough [POSITIVA/EMI]",
+        "artist": "Gorgon City",
+        "duration": "1:10:38",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      },
+      {
+        "id": "72a65944-d55b-4558-b5e6-352acbd9b9ae",
+        "title": "Adapter vs. Gorgon City & Katy Menditta – Pattak vs. Imagination (Gorgon City Edit) [CATCH & RELEASE / VIRGIN]",
+        "artist": "Gorgon City",
+        "duration": "1:14:34",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/ANTS-Ibiza-2025-Ushuaia-Ibiza.webp"
+      }
+    ]
+  },
+  {
+    "id": "5ed8f6be-71c5-44a0-9b83-531db3ad119f",
+    "title": "Gorgon City – Live at Creamfields 2025 (Sunday – Steel Yard)",
+    "artist": "Gorgon City",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp",
+    "tracks": [
+      {
+        "id": "a1c5cfb5-97b0-42ce-9dd4-27ab77387d86",
+        "title": "John Summit & Gorgon City ft. rhys from the sticks – Is Everybody Having Fun?",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "a7316f6d-3061-4a25-8798-084512a27ccd",
+        "title": "Da Skunk – Hot Box",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "6b786c43-7714-43f3-893a-b8a53de58d09",
+        "title": "DREYA V – Up Front",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "b24b6413-ba8f-40c0-b70a-8a2571516668",
+        "title": "Gorgon City – Voodoo",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "5f79767d-ed64-40cf-b045-7fc4c8b32a5b",
+        "title": "Ben Kim – Somebody To Love",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "41bc5148-dbd0-49d0-abe4-8502283db238",
+        "title": "w/ Chris Lorenzo – Appetite",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "9e86da08-b279-42ae-9ed2-94c479a29131",
+        "title": "Gorgon City – Tell Me It’s True (Terrace Dub)",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "d856f9e9-7c46-4ef9-8c9b-ad6a7855df5a",
+        "title": "Ronnie Spiteri – Power",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "3642bce6-d10c-4e31-b189-1c30c0d14f48",
+        "title": "MPH – Raw",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "c4f7e5a3-ce2b-43d6-b5cb-3677af18b50d",
+        "title": "Chloé Caillet & Luke Alessi ft. Jocelyn Brown – The One (HAAi Remix)",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "2b41ce06-93e5-4251-becb-0ce6407b2961",
+        "title": "Gorgon City ft. Caroline Byrne – All That You Need",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "3f9ea5cc-fc4f-4b01-8fec-721a9f470f76",
+        "title": "Gorgon City – 5 AM At Bagleys",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "a841f747-f36e-475a-81f8-2cb1130324fe",
+        "title": "The Prodigy – Breathe (HUMAN404 Remix)",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "0c89e45f-f8f5-45c7-9167-bb9a40d8a48d",
+        "title": "Danny Tenaglia ft. Celeda – Music Is The Answer (Dancin’ And Prancin’)",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "04b76426-6694-402e-a76c-cd86127de3c4",
+        "title": "Linska – Bad Boy (GENESI Remix)",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7596ada1-5fe1-42f9-91b0-1ce376820549",
+        "title": "L.P. Rhythm – Versatile",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "c5f7f26b-2222-4057-a53e-9fd8fada92e1",
+        "title": "Gorgon City – Loveless",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "af567b42-3358-4c89-8b9d-c648912c6ddc",
+        "title": "Gorgon City & MK – There For You",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "6bafddfb-0f99-44b2-9b09-d7e64026c247",
+        "title": "IDEMI – Someday",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "87a153a2-6fa6-4683-b2a5-c753b76394e7",
+        "title": "Gorgon City & DRAMA – You’ve Done Enough",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "bf60b4a7-5d7d-4408-9ce0-b6315d78f3ed",
+        "title": "Adapter – Pattak",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "3a5b2e7e-a8d7-415b-9883-b13cf8d061c4",
+        "title": "w/ Gorgon City ft. Katy Menditta – Imagination",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "61b4faae-bb7c-4fe8-af5c-37da865426c1",
+        "title": "Gorgon City ft. MNEK – Ready For Your Love",
+        "artist": "Gorgon City",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "074379f0-10d4-4539-85ec-fec4f4ad905f",
+    "title": "Eli Brown – Live at Creamfields 2025 (Saturday – Steel Yard)",
+    "artist": "Eli Brown",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp",
+    "tracks": [
+      {
+        "id": "664e6a14-2ffb-4bbd-a0fa-2a1ad1e8b3ba",
+        "title": ". Eli Brown – ID",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "c8f0b1cb-3631-4af5-9621-c3f16dfce0c9",
+        "title": ". Eli Brown & GeezLy – Me Gusta",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "484a6c2f-d1f3-496c-bd73-69cafc2415f5",
+        "title": ". HI-LO & Chocolate Puma vs. ATRIP – WTFU vs. GUMMI (HI-LO Mashup)",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "d7160072-4875-43f4-ae29-528f64b54176",
+        "title": ". ID – ID",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "e0bcb1a3-c427-4e84-b557-8173a979efad",
+        "title": ". Faithless – Insomnia (Daxson Bootleg)",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "599879e4-5720-4b59-b566-e845b1e7a711",
+        "title": ". Eli Brown vs. Tigerblind & Maddix – Diamonds On My Mind vs. Wildstyle vs. Believe (Eli Brown Mashup)",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "9983dce1-1ce0-4f0e-9b56-70217f785a3a",
+        "title": ". Eli Brown & Anna Reusch – ID",
+        "artist": "Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "84919d83-6981-432a-b633-5298c72910c3",
+    "title": "Max Styler – Live at Creamfields 2025 (Saturday – HALO)",
+    "artist": "Max Styler",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp",
+    "tracks": [
+      {
+        "id": "6456e2cb-7910-4e81-b79d-f56b8089a819",
+        "title": "Max Styler & Deomid – Get Down",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "5d4b1fb2-40bf-4c7a-baac-455d383484cb",
+        "title": "Max Styler – I Know You Want To",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "c01c29cf-7c23-4dfe-a72e-148cc5e562f0",
+        "title": "Gabss – Giddy Up",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "b94f9a3e-3d27-46e6-b8e9-fe2cd5d684ff",
+        "title": "Samantha Loveridge – Backtrack Blow Up (Max Styler Remix)",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "bb264dd9-a4bd-49e3-bad3-ed4da1421fee",
+        "title": "Vinter – Space Pump (Space Jam)",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "1edba865-f9f3-4de8-a0d5-9a0798de2264",
+        "title": "Max Styler – Hypnotic",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "c0a7ea21-14a9-4318-94b0-7334723a5c12",
+        "title": "w/ Tiga vs. Audion – Let’s Go Dancing (Acappella)",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "752c6f54-b33c-4238-8fdd-430e06da0401",
+        "title": "Uffie ft. Pharrell Williams – Add Suv (Armand van Helden Club Mix)",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "d20f8f62-ef53-450c-9d66-2f21212a5579",
+        "title": "Riton & Kah-Lo – Fake ID (Chris Lorenzo Edit)",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "03df8b6e-7036-48b2-8cff-92500d4ed33b",
+        "title": "Max Styler & Clüb De Combat – On Repeat",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "edab6cfe-3d2e-4155-a3cc-2aaef51a8ab6",
+        "title": "Sapian – Ruthless Kid",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "aee9cdaf-a757-488f-99d9-db39255a6f0f",
+        "title": "Julian Fijma – Get Stupid",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "a35fcc35-53e9-463b-be56-73d385f68fd9",
+        "title": "D-Jastic – Up To No Good",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "f82806bf-3079-463b-a804-5a2a2a24d17b",
+        "title": "Cromby – Best Not Miss",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "5a5d5adf-da5f-43ca-9c4b-3c8432cf2c0c",
+        "title": "Max Styler – Inferno",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "57ae89f1-f8b9-4192-ac09-b7db3ce3e458",
+        "title": "Three Drives – Greece 2000 (Max Styler Edit)",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "e3d35ddf-a169-4ca2-bd20-c66606b6ef07",
+        "title": "Mau P – Like I Like It",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "e5e58631-5df2-4eb9-8608-f7b7a165d59a",
+        "title": "Tigerblind – Got To Be",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "87a0e45e-34a7-44a4-b66a-fefb24bcb11a",
+        "title": "William Kiss – Midnight Club",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "1aca1544-01f6-4ebe-8242-fc65dff9ceac",
+        "title": "L.P. Rhythm – Versatile",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "38091ae7-c684-44cd-926f-59d1601085c9",
+        "title": "Chris Lorenzo & Max Styler & Audio Bullys – London’s On Fire",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "b0bb6ed7-a502-4c45-8f3e-1860f019d1a1",
+        "title": "Dom Dolla & Max Styler – Work It",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "9defc193-dc8e-467a-98ce-9d75522b58df",
+        "title": "Max Styler & Deomid – Every Night",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "dc4daf20-bf5a-48b7-82f9-0e2ea5ea867a",
+        "title": "Klubbheads – Rock The Party",
+        "artist": "Max Styler",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "869b7064-add0-4196-9e23-5abf6c32e4f5",
+    "title": "Mau P – Live at Creamfields 2025 (Friday – APEX)",
+    "artist": "Mau P",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp",
+    "tracks": [
+      {
+        "id": "cbff8825-22f7-4021-8b74-563eefbc0c9f",
+        "title": ". AYYBO & Discip – 4 YA MIND",
+        "artist": "Mau P",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "52ac9677-d655-4d10-ab9a-b778f89d092b",
+        "title": ". ID – ID",
+        "artist": "Mau P",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "24306af7-c8da-4436-a77e-c9667a2a635c",
+        "title": ". ID – ID",
+        "artist": "Mau P",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "a14264c2-ee94-4079-8d8a-484c962d14ea",
+    "title": "John Summit – Live at Creamfields 2025 (Friday – Steel Yard)",
+    "artist": "John Summit",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp",
+    "tracks": [
+      {
+        "id": "8f109173-efab-4713-8a23-9d98efb32335",
+        "title": "John Summit & Gorgon City ft. rhys from the sticks – Is Everybody Having Fun?",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7672a33f-9418-4899-96f3-98c256e68d07",
+        "title": "Laherte – Pump Up The Jam",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "18ef5330-fc91-43df-b417-fe01c8686689",
+        "title": "Roddy Lima – Night Time",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "8a4a42ce-29fb-44a9-a983-71b6b977c321",
+        "title": "Masters At Work – Work (Skytech Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "49a23e8a-1b0e-4e21-9c0e-32d7b8eeef51",
+        "title": "John Summit & HAYLA – Shiver (Cassian Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "ca363239-2213-447c-8714-debedab992d3",
+        "title": "Roddy Lima – Shadows",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "08b6af56-895d-4e84-9e7f-c5e687a82fd3",
+        "title": "Green Velvet ft. Walter Philips – Shake And Pop (John Summit Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "2fe20c69-4e19-407f-8872-abe5119eda58",
+        "title": "Fallon – Diet Coke",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "63ad2560-6657-4aa1-a929-1f2349453c7c",
+        "title": "John Summit & venbee – palm of my hands (Odd Mob Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "5a18f520-55d1-44e4-9365-f7d480c1f3ec",
+        "title": "Layton Giordani ft. LINNEY & Sarah de Warren – Act Of God (CamelPhat Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "e2a8d56e-6be0-4c8e-915f-ea1fc91fef64",
+        "title": "Anyma & Adam Sellouk – Girls M.I.A",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "9064e77c-0df8-4399-b6cd-03010825a2e2",
+        "title": "The Temper Trap – Sweet Disposition (John Summit & Silver Panda Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7812babf-3c17-4bad-b0af-430a062dfe0b",
+        "title": "Korolova & JOA – My Mind",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "141176d1-a768-44ea-ac29-47ebd88dffc5",
+        "title": "MEDUZA – ID",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "e193958f-25af-4fab-9e4c-344b9247dd15",
+        "title": "John Summit & Tombz – Trip",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "d7be09ea-6a32-4b37-837c-b6d1f650e080",
+        "title": "John Summit ft. CLOVES – Focus (ALOK Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "fbd007ef-2fc6-45a4-a9ed-ad8d07534e45",
+        "title": "TouchTalk – Change It (Westend Edit)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "37068d0b-5a4c-49bc-9984-b19a791400d9",
+        "title": "John Summit ft. Inéz – Crystallized (JOA Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "fe0d320d-2e77-4f37-bc99-d1a9e5f818ab",
+        "title": "Fatboy Slim – Right Here, Right Now (Dave Summer Edit)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "e3a7cf56-a3ca-4703-9f80-155c6e98590c",
+        "title": "John Summit ft. Inéz – light years (Matt Sassari Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "540ca179-0a00-40bb-80e3-e55246edfbd0",
+        "title": "Daft Punk – Around The World (Westend Edit)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7686c221-941b-451f-9852-ac3a06356024",
+        "title": "Cassian – S.O.S",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "9acd0c46-3142-4ece-b9d3-b2e5e8ee896f",
+        "title": "John Summit ft. HAYLA – Where You Are",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "4e3ebab6-3b2c-43cc-b074-7c00c6921794",
+        "title": "Mathame – Koko",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "1b0f425a-2f66-476a-a2b0-2dcdb0b4fb40",
+        "title": "Delerium ft. Sarah McLachlan – Silence (John Summit Remix)",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "648aa95f-efc0-4c71-813c-a5a9b1772d7c",
+        "title": "John Summit & Sub Focus ft. Julia Church – Go Back",
+        "artist": "John Summit",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "e6e65048-f69a-4040-ad9b-c177d55c4f0e",
+    "title": "Adam Beyer – Live at Creamfields 2025 (Friday – Steel Yard)",
+    "artist": "Adam Beyer",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp",
+    "tracks": [
+      {
+        "id": "342fbc31-1bdd-42cf-8c95-d667575ca15a",
+        "title": "GENESI & Equinøx – Chemistry",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "ae7f87ac-4256-4142-8f10-b0cc0c4e3996",
+        "title": "Oscar L & Charles D (USA) – Lift Me Up",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "28e6a534-3c4e-4c5e-91c4-8211717bd3fe",
+        "title": "Mau P – Like I Like It (Eli Brown Edit)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "be1803e7-564f-461d-b451-639649a23aef",
+        "title": "KASIA & Charles D (USA) ft. Sarah de Warren – Psycho",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "117f86e7-6f49-49eb-8b93-8dfcda2a4914",
+        "title": "Faithless – We Come 1 (Adam Beyer Remix)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "a513d1d8-5cc7-4ffc-9e0e-e73b10f3c3b9",
+        "title": "Anyma & Baset – Neverland (From Japan) (HNTR Remix)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "a561f5a9-2575-4db1-8352-5cc2ef98f72e",
+        "title": "Goom Gum & RDNK – It’s Time To Get High",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7887eab8-4557-4e88-9572-453c79b42672",
+        "title": "Marco V – Loxia",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "73b39d26-ea17-4d13-9342-3b47d305a004",
+        "title": "Nas – I Can",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "91cb363b-9eab-4a91-9dd0-863204ad0d6b",
+        "title": "Christian Smith – Just Close Your Eyes",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "999f9ede-c262-4731-a1a1-03e69cbb997f",
+        "title": "Mila Journée & Olivier Giacomotto – Smash It",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "3bf28461-100a-4fcf-b732-511219fa5262",
+        "title": "Ugo Banchi – Dance With Ibiza (Linska Remix)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "cc02b37b-0450-4623-98b8-cfbec067b3e8",
+        "title": "Tiga – Mind Dimension (HUMAN404 Edit)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "1580f37a-3ff4-4034-a53c-288b24f96079",
+        "title": "Green Velvet – La La Land",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "c87c8453-d46a-4a1d-a826-8877b09e4206",
+        "title": "KAF3R – Wow",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7ea290ed-76a3-4f98-b9c3-725b48e1e233",
+        "title": "Tigerblind – Wildstyle",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "b506c520-09de-4c25-9c5e-cf01875f2eb4",
+        "title": "HI-LO – ID",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "6d15edca-83c7-4b55-bdd6-b9824d28be38",
+        "title": "w/ Danny Tenaglia ft. Celeda – Music Is The Answer (Dancin’ And Prancin’) (Acappella)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "8ea95c8c-09f7-4b8d-afb0-447ed7bfe62f",
+        "title": "Adam Sellouk & Paradoks – Cloud 9",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "04f99e11-5d3e-418c-bc81-a65cb9a40b43",
+        "title": "Mau P – BEATS FOR THE UNDERGROUND (HNTR Edit)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "7cef62e8-eb77-4013-96d4-62010857e628",
+        "title": "HI-LO – Reese",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "cfe2ec52-b85c-40f2-86e5-035fc87aac6b",
+        "title": "w/ Kx5 ft. HAYLA – Escape",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "5e3b2e47-1f65-4d46-a3f6-3726ba882a44",
+        "title": "Three Drives – Greece 2000 (Max Styler Edit)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "414fe9f1-6de0-4709-b66a-b46f1eda4233",
+        "title": "w/ Rhythm Controll – My House (In Beginning, There Was Jack… Acappella)",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      },
+      {
+        "id": "9cedde31-c0db-4e64-9769-bcc6e7d2d5b5",
+        "title": "Bart Skils & A.D.H.S. – Can’t Hear You",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Creamfields-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "a822b5b7-a956-4451-88ba-a163b5a3f7fd",
+    "title": "Adam Beyer – Live at Awakenings Festival 2025 (Beekse Bergen, Netherlands)",
+    "artist": "Adam Beyer",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp",
+    "tracks": [
+      {
+        "id": "19e221fc-bedd-4937-9bf1-2f449e952443",
+        "title": "GENESI & Equinøx – Chemistry",
+        "artist": "Adam Beyer",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "0f40124d-9f4c-4745-9ee3-02ca802d8f3f",
+        "title": "Victor Ruiz & Mila Journée – Stars",
+        "artist": "Adam Beyer",
+        "duration": "04:17",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "49ecda31-070c-40ce-96af-8c7ec0ef4f71",
+        "title": "Marco V – Loxia",
+        "artist": "Adam Beyer",
+        "duration": "08:12",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "04bdb6f2-13de-45c4-8b94-007bc4335ddf",
+        "title": "Faithless – We Come 1 (Adam Beyer Remix)",
+        "artist": "Adam Beyer",
+        "duration": "12:11",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "afc871f8-4f21-4c44-977d-13a467849b78",
+        "title": "Layton Giordani & Green Velvet – When It Kicks",
+        "artist": "Adam Beyer",
+        "duration": "16:43",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "3d9b756a-c705-4931-bd6f-656463a2b517",
+        "title": "Adam Beyer – Waypoint",
+        "artist": "Adam Beyer",
+        "duration": "20:15",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "0994ec82-38b5-47d6-a968-ecea60618d02",
+        "title": "Adam Beyer – Taking Back Control",
+        "artist": "Adam Beyer",
+        "duration": "28:03",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "648b54e9-e056-4105-8527-d92244cef1ca",
+        "title": "ADRIANNA – Never Never Land",
+        "artist": "Adam Beyer",
+        "duration": "31:20",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "ace3711f-a5b7-4c39-8584-3be6a43bc4fc",
+        "title": "Eli Brown & GeezLy – Me Gusta",
+        "artist": "Adam Beyer",
+        "duration": "38:56",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "9faeae93-2e39-4418-9ace-33ba12da1a9a",
+        "title": "2000 And One – Tropical Melons (LAAT Remix)",
+        "artist": "Adam Beyer",
+        "duration": "42:42",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "c850bb91-da68-4dc6-af57-d906fab5a6f6",
+        "title": "Charlotte de Witte – Red Angle",
+        "artist": "Adam Beyer",
+        "duration": "46:13",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "89fd7630-5235-43b7-a3d3-cb9cf8a82e96",
+        "title": "Adam Beyer & Julian Jeweil – Loca",
+        "artist": "Adam Beyer",
+        "duration": "51:52",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "758892a4-8f57-434c-b5a4-9c881f9a47e5",
+        "title": "Adam Beyer – Boundless",
+        "artist": "Adam Beyer",
+        "duration": "55:31",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "8542e4e5-1d18-4386-a44d-475e82c89045",
+        "title": "OZBEK & Zafer Atabey – My Culture",
+        "artist": "Adam Beyer",
+        "duration": "59:45",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "de134a2a-5776-4ace-a82a-cc44849e80b5",
+        "title": "ADRIANNA – Wild Electric (Monika Kruse Remix)",
+        "artist": "Adam Beyer",
+        "duration": "1:03:45",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "c65f193b-3138-4ab2-91b6-4c3ae3c0c9b6",
+        "title": "HI-LO – Reese",
+        "artist": "Adam Beyer",
+        "duration": "1:07:17",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "93339f79-07c3-4acb-971c-6c68d65b36b8",
+        "title": "Adam Beyer & Bart Skils – Your Mind",
+        "artist": "Adam Beyer",
+        "duration": "1:11:03",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "acc0beb7-b678-452e-98f1-19d0f6375bab",
+        "title": "Viv Castle & David LeSal – One Two",
+        "artist": "Adam Beyer",
+        "duration": "1:15:24",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "4d39d62d-18fe-4adb-8559-b24a1eeca167",
+        "title": "Armin van Buuren & Adam Beyer – Techno Trance",
+        "artist": "Adam Beyer",
+        "duration": "1:19:31",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "af4d492d-ef16-48db-8813-0bd76485b41f",
+        "title": "Mau P – Like I Like It (Eli Brown Edit)",
+        "artist": "Adam Beyer",
+        "duration": "1:23:45",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "43c2ce9b-21d0-4b42-b63a-94ce7d89064e",
+        "title": "Technotronic – Pump Up The Jam (Simone Zino Edit)",
+        "artist": "Adam Beyer",
+        "duration": "1:28:06",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "40e52212-0d57-4f95-912b-7979c71091a2",
+        "title": "SUDO – We Are Free",
+        "artist": "Adam Beyer",
+        "duration": "1:36:52",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "78039ffe-ef8c-4eca-8e7a-d47760caf071",
+        "title": "Kaufmann – Broncho’s Sandman",
+        "artist": "Adam Beyer",
+        "duration": "1:41:02",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "1864df81-2186-4172-b904-b1d4b06fd943",
+        "title": "Veerus – Mind Body Soul",
+        "artist": "Adam Beyer",
+        "duration": "1:45:45",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "d5bf20af-ca4b-466e-9fa7-d2c179254008",
+        "title": "Teenage Mutants & Heerhorst & Peter Pahn – Dark Clouds",
+        "artist": "Adam Beyer",
+        "duration": "1:49:47",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "f28f73a0-026c-437a-9040-7e695308d227",
+        "title": "Adam Beyer – The Distance Between Us",
+        "artist": "Adam Beyer",
+        "duration": "1:57:06",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "3985d983-640d-4546-a883-874c52d3ee16",
+    "title": "Mau P – Live at Awakenings Festival 2025 (Beekse Bergen, Netherlands)",
+    "artist": "Mau P",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp",
+    "tracks": [
+      {
+        "id": "a6c5f194-01a3-4883-93c8-09e476daa8db",
+        "title": "Chinonegro – Welcome 2000’s [8BIT]",
+        "artist": "Mau P",
+        "duration": "01:03",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "ad570a73-1d29-4f48-8a15-b1a91533ba9a",
+        "title": "Shaf Huse – Mavado (DJ Fronter Remix) [INMOTION]",
+        "artist": "Mau P",
+        "duration": "05:28",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "5bcc8106-74df-4741-b0e6-e2fd0f9a3826",
+        "title": "Chinonegro – Funky Beat [8BIT]",
+        "artist": "Mau P",
+        "duration": "09:52",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "927952ed-7510-4e74-9108-d92660cd2e31",
+        "title": "Tiger Stripes – Rockin’ [REKIDS]",
+        "artist": "Mau P",
+        "duration": "14:22",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "2c6e1cd6-9f1f-4d78-b49a-ef784e310038",
+        "title": "Chris Di Perri – Gheddo [BANDIDOS]",
+        "artist": "Mau P",
+        "duration": "17:14",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "6da0f3c3-edbd-49b0-98b2-55ba87000c4e",
+        "title": "Noir & Haze vs. Grey & Ron Costa – Around The Bane (Noir Mashup Treatment) [DIRTY STUFF/GRIS]",
+        "artist": "Mau P",
+        "duration": "21:12",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "e4ee5b90-2a1d-49ad-85c8-6ded11877922",
+        "title": "Karretero – Solid Rider [BANDIDOS]",
+        "artist": "Mau P",
+        "duration": "24:55",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "565d6879-42df-4e78-a0ce-f3317fdfbde3",
+        "title": "DJ Fronter – Tic Tac [HOTTRAX]",
+        "artist": "Mau P",
+        "duration": "28:42",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "23533c90-de99-4571-8a08-8a71346c62c5",
+        "title": "Oscar L – All About The Music [SPHERA]",
+        "artist": "Mau P",
+        "duration": "33:18",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "9fdc74b6-b92c-4990-b6f2-1c64f5f361b7",
+        "title": "Tony Romera – LA Street [EDIBLE]",
+        "artist": "Mau P",
+        "duration": "37:29",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "da2f9810-182d-4bdd-b65e-ca3cb367788e",
+        "title": "Detlef – Doit [ISSUES]",
+        "artist": "Mau P",
+        "duration": "40:43",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "7c96f7f3-3bca-4f27-8c09-94e2973d43fa",
+        "title": "Blackchild (ITA) – Agartha [SOLID GROOVES RAW]",
+        "artist": "Mau P",
+        "duration": "43:56",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "7513a993-9d47-48e4-8679-802fde88ef61",
+        "title": "DJ Fronter – Sapiencial",
+        "artist": "Mau P",
+        "duration": "53:18",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "d83a0b8e-fa55-493b-81cf-ac523ffe919e",
+        "title": "Makèz – Day Starter [NO ART]",
+        "artist": "Mau P",
+        "duration": "57:05",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "4d709780-59fa-4db1-92f6-e342c3c8931c",
+        "title": "DJ Fronter & Rinno Dj – Relief [TIME BANDITS]",
+        "artist": "Mau P",
+        "duration": "1:02:03",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "c1965f65-877c-456a-bfc8-87280a837a94",
+        "title": "Egbert – Straktrekken [GEM]",
+        "artist": "Mau P",
+        "duration": "1:05:46",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "4ba0bf81-c9be-43f8-b0fe-3c4ff11b30e7",
+        "title": "Cortes – Dutchmaster [DESOLAT]",
+        "artist": "Mau P",
+        "duration": "1:10:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "5ac86cbd-dfc0-4053-9365-e198b640b3b6",
+        "title": "Roberto Surace – Joys (Nic Fanciulli Edit) [DEFECTED]",
+        "artist": "Mau P",
+        "duration": "1:14:08",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "69c98811-eea0-4e80-80b1-fb23d9af9653",
+        "title": "Marco Lys – C’mon Girl [VIVA]",
+        "artist": "Mau P",
+        "duration": "1:19:01",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "599817fb-d969-45df-b72c-7f62cbe6a76a",
+        "title": "Rooléh – Impulse [SOLID GROOVES]",
+        "artist": "Mau P",
+        "duration": "1:22:57",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "b09bca85-8f28-469a-8fd2-883449d7f798",
+        "title": "Tommy Vee & Keller – Get Yourself [FLASHMOB]",
+        "artist": "Mau P",
+        "duration": "1:26:55",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "357cae40-f789-422b-a861-511dbb884e7d",
+        "title": "Mau P – MERTHER [DEFECTED]",
+        "artist": "Mau P",
+        "duration": "1:31:35",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "88492f3c-ab8f-4f65-a371-ef24d3cd163b",
+        "title": "Dale Howard – Nasty 90’s [MOXY MUZIK]",
+        "artist": "Mau P",
+        "duration": "1:36:05",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "9f3e79a2-46d6-4a95-9fb8-02f322007663",
+        "title": "Egbert – Wild [MINDSHAKE]",
+        "artist": "Mau P",
+        "duration": "1:40:24",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "95a5941c-eb77-4ec8-9af8-d248abbcedae",
+        "title": "nocapz. – Musikk Selekkktor [ORGANIC PIECES]",
+        "artist": "Mau P",
+        "duration": "1:45:01",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "ddc3cb11-8d4f-4d51-8f1f-d904a62f8e4d",
+        "title": "Mau P – Like I Like It [DIYNAMIC]",
+        "artist": "Mau P",
+        "duration": "1:49:41",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "30f8c1d8-0082-45f4-bb11-e90f74dce1b7",
+        "title": "Detlef – Oh Oh [HOT CREATIONS]",
+        "artist": "Mau P",
+        "duration": "1:54:37",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "bf9755b3-7a50-4a9b-b390-b40cb19ba033",
+        "title": "Anatta – Eye Contact [ANDHERA]",
+        "artist": "Mau P",
+        "duration": "1:58:58",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      },
+      {
+        "id": "5928e59d-64a7-47cc-bcc5-f8030669e709",
+        "title": "Crusy – Kiki [TOOLROOM]",
+        "artist": "Mau P",
+        "duration": "2:01:56",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/08/Awakenings-Festival-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "0723026f-2575-4440-9dec-712ac57d559a",
+    "title": "Cassian – Live at Tomorrowland 2025 (W2 Day 3 – Freedom Stage)",
+    "artist": "Cassian",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp",
+    "tracks": [
+      {
+        "id": "5e60c088-93e7-411b-8e28-b41451a7ca62",
+        "title": ". ID – ID",
+        "artist": "Cassian",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "019b7b9f-80f2-4324-b128-b1741e11609a",
+        "title": ". SLVR – Music 4 Ur Body",
+        "artist": "Cassian",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "33108a3f-1f1d-4ef8-b24c-b397113a7b7b",
+        "title": ". Da Hool – Meet Her At The Love Parade (YOTTO & Cassian Rework)",
+        "artist": "Cassian",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "e2a7a82d-75ea-4052-b67d-f1269b8dbb05",
+        "title": ". Cassian – ID",
+        "artist": "Cassian",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "de7891a0-acf4-4cc3-a2a0-7d2459d54ad9",
+        "title": ". CamelPhat & Kölsch – Waste My Time (Chris Avantgarde Remix)",
+        "artist": "Cassian",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "31d8d4aa-2b83-42b9-afc8-e8ca1a3ade6c",
+    "title": "Kaskade – Live at Tomorrowland 2025 (W2 Day 1 – Mainstage)",
+    "artist": "Kaskade",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp",
+    "tracks": [
+      {
+        "id": "063c81c7-f196-4b61-9e45-9412ae616843",
+        "title": ". Kaskade & Lipless vs. Victor Ruiz & Mila Journée – State Of Mind vs. Stars (Kaskade Edit)",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "bc224449-cec1-4c92-a4ec-9fc6d6f1ae66",
+        "title": ". Kaskade – ID",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "c8373041-3e52-4409-962d-bf89b4d830e6",
+        "title": ". Kaskade – ID",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "bf02b95d-b54b-4aa0-95f7-5fdee56e40b3",
+        "title": ". Kaskade & Tess Comrie vs. Martin Ikin – Never Sleep Alone vs. In The Streets (Kaskade Edit)",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "22f5387a-3a7a-4ad5-b0ea-2695f285e85d",
+        "title": ". Kaskade – ID",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "13572b68-3bc7-4f19-9752-92f659c23996",
+        "title": ". Kaskade – ID",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "2ee26fe6-e042-4060-bbfb-8c47896f56c6",
+        "title": ". Paul Johnson – Get Get Down (LAWZ Edit)",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "1680db2f-580e-4198-a662-7f6ba2b1e00c",
+        "title": ". Fatboy Slim – Right Here, Right Now (Dave Summer Edit)",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "8fbf511b-c31b-495c-9850-17ae77943542",
+        "title": ". Kaskade – ID",
+        "artist": "Kaskade",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "a2ecec0c-f695-485c-9a31-7390da3116c9",
+    "title": "Cassian b2b Kevin De Vries – Live at Tomorrowland 2025 (Day 2 – Mainstage)",
+    "artist": "Cassian b2b Kevin De Vries",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp",
+    "tracks": [
+      {
+        "id": "71f28762-35ae-4118-8d82-f9e85d105b25",
+        "title": "Cassian – ID",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "43e0c1bc-6ea6-47bc-8758-7609b6a3a982",
+        "title": "Jas/t – Move",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "04:05",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "2016b80c-4159-42be-adf6-42450bb3e13f",
+        "title": "Cassian & SCRIPT & Belladonna – Where I’m From [THREE SIX ZERO]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "07:15",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "a2df6155-219d-48a5-bf4e-10148d29bfbc",
+        "title": "CamelPhat & Anyma – The Sign (Kevin de Vries Remix) [AFTERLIFE/INTERSCOPE]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "10:55",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "f4d52a66-9dd6-448d-b88e-e1614e0c2280",
+        "title": "Cassian – Dun Dun [AFTERLIFE]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "14:06",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "d18d5c78-937b-4144-9386-49c9e463c340",
+        "title": "JOA – No Games",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "19:40",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "d8b16524-425e-4b63-bb15-5c837152ee51",
+        "title": "Cassian – S.O.S [EXPERTS ONLY]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "23:18",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "c100b9a5-929a-439a-83dc-2176dd91d9f2",
+        "title": "Fred again.. & Skepta & PlaqueBoyMax – Victory Lap (Adam Sellouk & UN:COMN Remix) [ATLANTIC (WARNER MUSIC)]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "26:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "4e3c5454-2f92-4a2e-bc0a-eb2a171a7edc",
+        "title": "Da Hool – Meet Her At The Love Parade (YOTTO & Cassian Rework)",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "26:30",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "eb96d705-23ad-4ace-9d75-f29ddc9ef48e",
+        "title": "Chris Avantgarde – Energy [DRUMCODE]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "29:05",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "1dcc3c77-2f06-4ef4-b35e-79f62cc6a47f",
+        "title": "Goom Gum – Enough [AVTOOK]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "32:15",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "fa6df15f-ef06-4257-8b41-d62a23d3ff93",
+        "title": "MEDUZA ft. HAYLA – Another World (Kevin de Vries & SLVR Remix) [ISLAND (UMG)]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "35:15",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "2d7cc979-ddeb-473f-aced-25f08959d166",
+        "title": "Calvin Harris ft. Clementine Douglas – Blessings (Cassian Remix) [COLUMBIA (SONY)]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "39:05",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "10ae3e1b-d39b-4e64-966f-7cd5445f4920",
+        "title": "Kevin de Vries & Jas/t – Born Like That",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "43:20",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "b8e348b8-4c39-4b0f-9f89-ac80b15d0133",
+        "title": "Mila Journée & Olivier Giacomotto – Smash It [SIMULATE]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "46:40",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "4ed08df6-9787-4347-8d51-afa76ac7fd16",
+        "title": "Dimitri Vangelis & Wyman X Steve Angello – Payback (Kevin de Vries & Cassian Remix) [COLUMBIA (SONY)]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "49:37",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "75aa7231-9d2f-41ed-be60-74718e99f680",
+        "title": "John Summit & HAYLA – Shiver (Cassian Remix) [EXPERTS ONLY/DARKROOM REC.]",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "53:20",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "d1d849a3-155c-4694-9cbc-fdd7e4a2bb5c",
+        "title": "CamelPhat & Kölsch – Waste My Time (Chris Avantgarde Remix)",
+        "artist": "Cassian b2b Kevin De Vries",
+        "duration": "57:25",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      }
+    ]
+  },
+  {
+    "id": "938cc8c4-f3fa-47cb-86be-ed447e14f8d0",
+    "title": "HI-LO & Eli Brown – Live at Tomorrowland 2025 (Day 1 – Freedom Stage)",
+    "artist": "HI-LO & Eli Brown",
+    "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp",
+    "tracks": [
+      {
+        "id": "1bc4aa24-3873-4cfd-add2-885b9dd0a636",
+        "title": ". Mau P – Like I Like It (Eli Brown Edit)",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "49e0a70a-d3ab-48b7-a766-5f16fe83bb82",
+        "title": ". HI-LO – ID (Rhythm Of Life)",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "2f7620a6-abad-40a9-9204-b31740b2af19",
+        "title": ". Eli Brown vs. Tigerblind & Maddix – Diamonds On My Mind vs. Wildstyle vs. Believe (Eli Brown Mashup)",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "82e68630-958e-491d-b99c-2ac4c0ce083e",
+        "title": ". Eli Brown & GeezLy – Papi",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "2f41a77f-c438-42b1-8b1b-743dea76fe11",
+        "title": ". HI-LO & Chocolate Puma vs. ATRIP – WTFU vs. GUMMI (HI-LO Mashup)",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "2692c4a6-9574-4fe7-90e9-30ae0c2d9333",
+        "title": ". Eli Brown – ID",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      },
+      {
+        "id": "3414cacc-50f6-4b21-a54e-dd3bd2a5c356",
+        "title": ". Eli Brown & Anna Reusch – ID",
+        "artist": "HI-LO & Eli Brown",
+        "duration": "00:00",
+        "artwork": "https://cdn.edmliveset.com/wp-content/uploads/2025/07/Tomorrowland-2025.webp"
+      }
+    ]
+  }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2577 @@
+{
+  "name": "ezdm",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ezdm",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "uuid": "^13.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.14.0",
+        "@types/uuid": "^10.0.0",
+        "@vitejs/plugin-react": "^5.0.0",
+        "axios": "^1.12.2",
+        "cheerio": "^1.1.2",
+        "ts-node": "^10.9.2",
+        "typescript": "~5.8.2",
+        "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
+      "integrity": "sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.4.tgz",
+      "integrity": "sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.38",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.11.tgz",
+      "integrity": "sha512-i+sRXGhz4+QW8aACZ3+r1GAKMt0wlFpeA8M5rOQd0HEYw9zhDrlx9Wc8uQ0IdXakjJRthzglEwfB/yqIjO6iDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001747",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001747.tgz",
+      "integrity": "sha512-mzFa2DGIhuc5490Nd/G31xN1pnBnYMadtkyTjefPI7wzypqgCEpeWu9bJr0OnDsyKrW75zA9ZAt7pbQFmwLsQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.230.tgz",
+      "integrity": "sha512-A6A6Fd3+gMdaed9wX83CvHYJb4UuapPD5X5SLq72VZJzxHSY0/LUweGXRWmQlh2ln7KV7iw7jnwXK7dlPoOnHQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
+      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,12 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react": "^19.2.0"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "axios": "^1.12.2",
+    "cheerio": "^1.1.2",
+    "ts-node": "^10.9.2",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   }


### PR DESCRIPTION
This commit introduces a new utility to import music catalog items from edmliveset.com.

The utility fetches the HTML of a given URL, parses it using cheerio to extract album and track information, and stores the data in a new file.

The key features of this utility are:
- It uses `axios` for HTTP requests and `cheerio` for robust HTML parsing.
- It is flexible and handles multiple tracklist formats found on the target website, including both timestamped and simple numbered lists.
- It generates unique IDs for all imported albums and tracks using the `uuid` library.

An `import-script.ts` is included to run the import process for a predefined list of URLs. The script writes the final, structured data to `new-data.ts`, which can then be integrated into the application.